### PR TITLE
Fix error in the build caused by wrong bucket name

### DIFF
--- a/LexAppBuilder/ModelBuilder.js
+++ b/LexAppBuilder/ModelBuilder.js
@@ -110,8 +110,8 @@ function buildFunctionZipInS3(botName, model, s3bucket, timestamp) {
 
     const s3 = new AWS.S3();
     const params = {
-      Bucket: s3bucket + '/artifacts',
-      Key: "processBotInfo" + botName + timestamp + ".zip",
+      Bucket: s3bucket,
+      Key: "artifacts/processBotInfo" + botName + timestamp + ".zip",
       Body: fs.createReadStream(localZipName)
     };
 
@@ -133,8 +133,8 @@ function uploadYamlToS3(yaml, botName, s3bucket) {
   return new Promise(function (resolve, reject) {
     const s3 = new AWS.S3();
     const params = {
-      Bucket: s3bucket + '/artifacts',
-      Key: 'lex' + botName + '.yaml',
+      Bucket: s3bucket,
+      Key: 'artifacts/lex' + botName + '.yaml',
       Body: fs.createReadStream(yaml)
     };
 
@@ -167,8 +167,8 @@ function buildCFCustomResourcesZipInS3(botName, s3bucket, timestamp) {
     const s3 = new AWS.S3();
 
     const params = {
-      Bucket: s3bucket + '/artifacts',
-      Key: "custom-resources" + timestamp + ".zip",
+      Bucket: s3bucket,
+      Key: "artifacts/custom-resources" + timestamp + ".zip",
       Body: fs.createReadStream(localZipName)
     };
 


### PR DESCRIPTION
Fixes an error when CodeBuild is preparing the Lex bot:
Could not build function zip in s3InvalidBucket: Bucket names cannot contain forward slashes. Bucket: trackingbot-artifactstore-xxxxxxxxx/artifacts