### PR TITLE
Set LexAppBuilder to use adm-zip version 0.4.7 and set codebuild setu…

### DIFF
--- a/LexAppBuilder/package.json
+++ b/LexAppBuilder/package.json
@@ -5,7 +5,7 @@
   "license": "Amazon Software License",
   "main": "index.js",
   "dependencies": {
-    "adm-zip": "^0.4.7",
+    "adm-zip": "0.4.7",
     "aws-sdk": "^2.57.0",
     "jsonschema": "^1.1.1",
     "minimist": "^1.2.0",

--- a/master-cft.yaml
+++ b/master-cft.yaml
@@ -513,7 +513,7 @@ Resources:
                                 - echo "INFO install cmds"
                                 - yum install zip -y
                                 - npm install -g n
-                                - n stable
+                                - n 9.3.0
                                 - npm update -g npm
                         pre_build:
                             commands:


### PR DESCRIPTION
…p to install node 9.3.0 instead of node v10. Both of these versions will allow the current build processing to complete successfully